### PR TITLE
Add support for commands monitoring JOIN events

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/rand"
 	"time"
+	"strings"
 
 	"github.com/robfig/cron"
 )
@@ -61,7 +62,17 @@ func (b *Bot) startPeriodicCommands() {
 }
 
 // MessageReceived must be called by the protocol upon receiving a message
-func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *User) {
+func (b *Bot) MessageReceived(eventCode string, channel *ChannelData, message *Message, sender *User) {
+	if message == nil {
+		b.ExecuteEventCommands(&EventCmd{
+			EventCode: eventCode,
+			Channel: strings.TrimSpace(channel.Channel),
+			ChannelData: channel,
+			User: sender,
+		})
+		return
+	}
+
 	command, err := parse(message.Text, channel, sender)
 	if err != nil {
 		b.handlers.Response(channel.Channel, err.Error(), sender)

--- a/cmd.go
+++ b/cmd.go
@@ -47,6 +47,13 @@ type PassiveCmd struct {
 	User        *User        // User who sent this message
 }
 
+type EventCmd struct {
+	EventCode string // Which event code has actually occured
+	Channel string // Channel wich the message was sent to
+	ChannelData *ChannelData // Channel and network info
+	User *User // User who sent this message
+}
+
 // PeriodicConfig holds a cron specification for periodically notifying the configured channels
 type PeriodicConfig struct {
 	CronSpec string                               // CronSpec that schedules some function
@@ -91,11 +98,13 @@ const (
 type passiveCmdFunc func(cmd *PassiveCmd) (string, error)
 type activeCmdFuncV1 func(cmd *Cmd) (string, error)
 type activeCmdFuncV2 func(cmd *Cmd) (CmdResult, error)
+type eventCmdFunc func(cmd *EventCmd) (string, error)
 
 var (
 	commands         = make(map[string]*customCommand)
 	passiveCommands  = make(map[string]passiveCmdFunc)
 	periodicCommands = make(map[string]PeriodicConfig)
+	eventCommands	 = make(map[string]eventCmdFunc)
 )
 
 // RegisterCommand adds a new command to the bot.
@@ -135,6 +144,14 @@ func RegisterPassiveCommand(command string, cmdFunc func(cmd *PassiveCmd) (strin
 	passiveCommands[command] = cmdFunc
 }
 
+// RegisterEventCommand adds a new passive command to the bot.
+// The command should be registered in the Init() func of your package
+// command: String which the user will use to add some behavior in some irc event
+// cmdFunc: Function which will be executed once the irc event occurs
+func RegisterEventCommand(command string, cmdFunc eventCmdFunc) {
+	eventCommands[command] = cmdFunc
+}
+
 // RegisterPeriodicCommand adds a command that is run periodically.
 // The command should be registered in the Init() func of your package
 // config: PeriodicConfig which specify CronSpec and a channel list
@@ -155,6 +172,34 @@ func (b *Bot) executePassiveCommands(cmd *PassiveCmd) {
 	mutex := &sync.Mutex{}
 
 	for k, v := range passiveCommands {
+		if b.isDisabled(k) {
+			continue
+		}
+
+		cmdFunc := v
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			result, err := cmdFunc(cmd)
+			if err != nil {
+				log.Println(err)
+			} else {
+				mutex.Lock()
+				b.handlers.Response(cmd.Channel, result, cmd.User)
+				mutex.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (b *Bot) ExecuteEventCommands(cmd *EventCmd) {
+	var wg sync.WaitGroup
+	mutex := &sync.Mutex{}
+
+	for k, v := range eventCommands {
 		if b.isDisabled(k) {
 			continue
 		}

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -76,6 +76,23 @@ func onCTCPACTION(e *ircevent.Event) {
 		})
 }
 
+func onJOIN(e *ircevent.Event) {
+	b.MessageReceived(
+		e.Code,
+		&bot.ChannelData{
+			Protocol: "irc",
+			Server: ircConn.Server,
+			Channel: e.Arguments[0],
+			IsPrivate: false,
+		},
+		nil,
+		&bot.User{
+			ID: e.Host,
+			Nick: e.Nick,
+			RealName: e.User,
+		})
+}
+
 func getServerName(server string) string {
 	separatorIndex := strings.LastIndex(server, ":")
 	if separatorIndex != -1 {
@@ -110,6 +127,7 @@ func Run(c *Config) {
 	ircConn.AddCallback("001", onWelcome)
 	ircConn.AddCallback("PRIVMSG", onPRIVMSG)
 	ircConn.AddCallback("CTCP_ACTION", onCTCPACTION)
+	ircConn.AddCallback("JOIN", onJOIN)
 
 	err := ircConn.Connect(c.Server)
 	if err != nil {

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -41,6 +41,7 @@ func responseHandler(target string, message string, sender *bot.User) {
 
 func onPRIVMSG(e *ircevent.Event) {
 	b.MessageReceived(
+		e.Code,
 		&bot.ChannelData{
 			Protocol:  "irc",
 			Server:    ircConn.Server,
@@ -57,6 +58,7 @@ func onPRIVMSG(e *ircevent.Event) {
 
 func onCTCPACTION(e *ircevent.Event) {
 	b.MessageReceived(
+		e.Code,
 		&bot.ChannelData{
 			Protocol:  "irc",
 			Server:    ircConn.Server,


### PR DESCRIPTION
This allow implementation of commands/plugins that relies on JOIN events like the "greetings" command that we were thinking about.

A simple example of using this feature would be like the following one:

```
package greetings

import (
	"github.com/meleca/bot"
)

func sayHello(cmd *bot.EventCmd) (string, error) {
	message := "hello " + cmd.User.Nick
	return message, nil
}

func init() {
	bot.RegisterEventCommand(
		"greetings",
		sayHello)
}
```

If you guys think something could be done in a better way, please let me know.

PS.: this PR solves issue #1 