### PR TITLE
Add support for commands monitoring events-only

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/rand"
 	"time"
+	"strings"
 
 	"github.com/robfig/cron"
 )
@@ -62,6 +63,16 @@ func (b *Bot) startPeriodicCommands() {
 
 // MessageReceived must be called by the protocol upon receiving a message
 func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *User) {
+	if message.Text == "" {
+		b.ExecuteEventCommands(&EventCmd{
+			EventCode: message.EventCode,
+			Channel: strings.TrimSpace(channel.Channel),
+			ChannelData: channel,
+			User: sender,
+		})
+		return
+	}
+
 	command, err := parse(message.Text, channel, sender)
 	if err != nil {
 		b.handlers.Response(channel.Channel, err.Error(), sender)

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -74,6 +74,24 @@ func onCTCPACTION(e *ircevent.Event) {
 		})
 }
 
+func onJOIN(e *ircevent.Event) {
+	b.MessageReceived(
+		&bot.ChannelData{
+			Protocol: "irc",
+			Server: ircConn.Server,
+			Channel: e.Arguments[0],
+			IsPrivate: false,
+		},
+		&bot.Message{
+			EventCode: e.Code,
+		},
+		&bot.User{
+			ID: e.Host,
+			Nick: e.Nick,
+			RealName: e.User,
+		})
+}
+
 func getServerName(server string) string {
 	separatorIndex := strings.LastIndex(server, ":")
 	if separatorIndex != -1 {
@@ -108,6 +126,7 @@ func Run(c *Config) {
 	ircConn.AddCallback("001", onWelcome)
 	ircConn.AddCallback("PRIVMSG", onPRIVMSG)
 	ircConn.AddCallback("CTCP_ACTION", onCTCPACTION)
+	ircConn.AddCallback("JOIN", onJOIN)
 
 	err := ircConn.Connect(c.Server)
 	if err != nil {


### PR DESCRIPTION
Correcting the last PR closed: no changes were made on callback interface, thus not breaking Slack/Telegram calls.

This allow implementation of commands/plugins that relies on JOIN events like the "greetings" command that we were thinking about.

A simple example of using this feature would be like the following one:
```
package greetings

import (
	"fmt"
	"github.com/meleca/bot"
)

func SayHello(cmd *bot.EventCmd) (string, error) {
	if cmd.EventCode == "JOIN" {
		message := "hello " + cmd.User.Nick
		return message, nil
	}
	return "", nil
}

func init() {
	bot.RegisterEventCommand(
		"greetings",
		SayHello)
}
```

If you guys think something could be done in a better way, please let me know.

PS.: this PR solves issue #1 